### PR TITLE
Removed unnecesary pipeline variable

### DIFF
--- a/src/VstsDemoBuilder/Templates/Tailwind Traders/BuildDefinitionGitHub/Website-CI.json
+++ b/src/VstsDemoBuilder/Templates/Tailwind Traders/BuildDefinitionGitHub/Website-CI.json
@@ -35,9 +35,6 @@
     "system.debug": {
       "value": "false",
       "allowOverride": true
-    },
-    "useremail": {
-      "value": "rimman@microsoft.com"
     }
   },
   "retentionRules": [
@@ -87,7 +84,7 @@
               "csmParametersFileLink": "",
               "csmFile": "Deploy/deployment.json",
               "csmParametersFile": "",
-              "overrideParameters": "-userEmail $(useremail)",
+              "overrideParameters": "",
               "deploymentMode": "Incremental",
               "enableDeploymentPrerequisites": "None",
               "deploymentGroupEndpoint": "",


### PR DESCRIPTION
userEmail variable from TrailwindTraiders-website CI pipeline is not building due to an non-existing parameter at the template level.

![image](https://user-images.githubusercontent.com/13256077/60377643-c2214980-99e6-11e9-89d9-4ba4fb0fa449.png)

This breaks the walkthrough demo from https://github.com/Microsoft/TailwindTraders/tree/master/Documents/DemoScripts/Integrating%20Azure%20Pipelines,%20GitHub%20and%20Azure%20Boards#integrating-azure-pipelines-github-and-azure-boards 

