### PR TITLE
converting github url to raw url - still works for raw url #240

### DIFF
--- a/src/VstsDemoBuilder/Controllers/EnvironmentController.cs
+++ b/src/VstsDemoBuilder/Controllers/EnvironmentController.cs
@@ -131,7 +131,7 @@ namespace VstsDemoBuilder.Controllers
                     _templates.Groups = new List<string>();
                     foreach (var group in templates.Groups)
                     {
-                        if (group.ToLower() != "private")
+                        //if (group.ToLower() != "private")
                         {
                             _templates.Groups.Add(group);
                         }

--- a/src/VstsDemoBuilder/Controllers/EnvironmentController.cs
+++ b/src/VstsDemoBuilder/Controllers/EnvironmentController.cs
@@ -131,10 +131,7 @@ namespace VstsDemoBuilder.Controllers
                     _templates.Groups = new List<string>();
                     foreach (var group in templates.Groups)
                     {
-                        //if (group.ToLower() != "private")
-                        {
-                            _templates.Groups.Add(group);
-                        }
+                        _templates.Groups.Add(group);
                     }
                     templates.Groups = _templates.Groups;
                 }

--- a/src/VstsDemoBuilder/Scripts/AppScripts/FileUpload.js
+++ b/src/VstsDemoBuilder/Scripts/AppScripts/FileUpload.js
@@ -110,8 +110,8 @@
         }
         if (controlID === 'btnGitHubUpload') {
 
-            if (fileurlSplit[2].toLowerCase() !== "raw.githubusercontent.com") {
-                $("#urlerror").empty().append('Please provide GitHub raw URL, which should starts with domain name raw.githubusercontent.com '); isUrlValid = false;
+            if (fileurlSplit[2].toLowerCase() !== "raw.githubusercontent.com" && fileurlSplit[2].toLowerCase() !== "github.com") {
+                $("#urlerror").empty().append('Please provide GitHub URL, which should starts with domain name raw.githubusercontent.com or github.com '); isUrlValid = false;
             }
             else if ($('#privateGitHubRepo').prop("checked") === true && GitHubtoken === '') {
                 $("#urlerror").empty().append('Please provide GitHub access token for authentication'); isUrlValid = false;

--- a/src/VstsDemoBuilder/Services/TemplateService.cs
+++ b/src/VstsDemoBuilder/Services/TemplateService.cs
@@ -162,7 +162,13 @@ namespace VstsDemoBuilder.Services
                     Directory.CreateDirectory(HostingEnvironment.MapPath("~") + @"\ExtractedZipFile");
                 }
                 var path = HostingEnvironment.MapPath("~") + @"\ExtractedZipFile\" + ExtractedTemplate;
-
+                if (uri.Host == "github.com")
+                {
+                    string gUri = uri.ToString();
+                    gUri = gUri.Replace("github.com", "raw.githubusercontent.com").Replace("/blob/", "/");
+                    uri = new Uri(gUri);
+                    TemplateUrl = uri.ToString();
+                }
                 //Downloading template from source of type github
                 if (uri.Host == "raw.githubusercontent.com")
                 {

--- a/src/VstsDemoBuilder/Views/Environment/PrivateTemplate.cshtml
+++ b/src/VstsDemoBuilder/Views/Environment/PrivateTemplate.cshtml
@@ -55,11 +55,11 @@
                 </div>
                 <div class="d-none" id="GitHubUpload">
                     <p>
-                        Provide the RAW URL to your private template (zip file). Note: If your repo is private, you will need to provide a
+                        Provide the github URL to your private template (zip file). Note: If your repo is private, you will need to provide a
                         <a href="https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line"  target="_blank"> Personal Access Token</a>
                     </p>
 
-                    <div class="form-group"><input class="form-control" type="text" id="GitHubUrl" placeholder="https://raw.githubusercontent.com/{GitHubID}/{RepoName}/master/{templatefile}.zip"></div>
+                    <div class="form-group"><input class="form-control" type="text" id="GitHubUrl" placeholder="https://github.com/{GitHub-ID}/{RepoName}/{Branch}/{FileName}.zip"></div>
                     <div class="form-group">
                         <div class="col-lg-6"></div>
                         <div class="col-lg-6">


### PR DESCRIPTION
Based on user suggestion, accepting GitHub zip file link instead of raw URL

Closes #240 