### PR TITLE
Update Terraform template token replacement

### DIFF
--- a/src/VstsDemoBuilder/Templates/Terraform/ReleaseDefinitions/Terraform.json
+++ b/src/VstsDemoBuilder/Templates/Terraform/ReleaseDefinitions/Terraform.json
@@ -174,6 +174,7 @@
                 "keepToken": "false",
                 "tokenPrefix": "__",
                 "tokenSuffix": "__",
+                "tokenPattern": "rm",
                 "emptyValue": "(empty)"
               }
             },


### PR DESCRIPTION
The token replacement step was not working because the default token replacement pattern doesn't match the terraform file.  Setting that to rm which is the "__ ... __" pattern